### PR TITLE
Backend RF006 Deletar Quadros Anotacoes de um canvas

### DIFF
--- a/server/src/PushIt/Controllers/CanvasController.cs
+++ b/server/src/PushIt/Controllers/CanvasController.cs
@@ -109,6 +109,8 @@ public class CanvasController : ControllerBase{
          return NoContent();
     }
 
+
+    //DELETE /canvas/nomecanvas/quadros/iddoquadro
     [HttpDelete("/canvas/{name}/quadros/{id}")]
     public IActionResult DeleteQuadro(string name, string id)
     {

--- a/server/src/PushIt/Controllers/CanvasController.cs
+++ b/server/src/PushIt/Controllers/CanvasController.cs
@@ -112,7 +112,12 @@ public class CanvasController : ControllerBase{
     [HttpDelete("/canvas/{name}/quadros/{id}")]
     public IActionResult DeleteQuadro(string name, string id)
     {
-        return Ok();
+        if(!this._canvasService.DeleteQuadro(name, id))
+        {
+            return NotFound();
+        }
+
+        return NoContent();
     }
 
     //PUT /canvas/name

--- a/server/src/PushIt/Controllers/CanvasController.cs
+++ b/server/src/PushIt/Controllers/CanvasController.cs
@@ -109,11 +109,11 @@ public class CanvasController : ControllerBase{
          return NoContent();
     }
 
-    // [HttpDelete("/canvas/{name}/quadros/{id}")]
-    // public IActionResult DeleteQuadro(string name, string id)
-    // {
-    //     return Ok();
-    // }
+    [HttpDelete("/canvas/{name}/quadros/{id}")]
+    public IActionResult DeleteQuadro(string name, string id)
+    {
+        return Ok();
+    }
 
     //PUT /canvas/name
     // [HttpPut("/canvas/{name}")]

--- a/server/src/PushIt/Models/Canvas.cs
+++ b/server/src/PushIt/Models/Canvas.cs
@@ -49,4 +49,18 @@ public class Canvas
 
         return true;
     }
+
+    public bool DeleteQuadro(string quadroId)
+    {
+        int index = this.QuadrosAnotacoes.FindIndex(
+            q => q.id == quadroId
+        );
+
+        if(index < 0 ) { return false; }
+
+        this.QuadrosAnotacoes.RemoveAt(index);
+        this.LastModification = DateTime.Now;
+
+        return true;
+    }
 }

--- a/server/src/PushIt/Requests/PushIt.http
+++ b/server/src/PushIt/Requests/PushIt.http
@@ -40,7 +40,7 @@ Content-Type: application/json
 
 ###
 
-GET {{PushIt_HostAddress}}/canvas/placeholder/quadros/IDhere11
+GET {{PushIt_HostAddress}}/canvas/placeholder/quadros/IDhere
 Accept: application/json
 
 ###
@@ -48,14 +48,14 @@ Accept: application/json
 GET {{PushIt_HostAddress}}/canvas/placeholder/quadros
 Accept: application/json
 
+###
+
+DELETE {{PushIt_HostAddress}}/canvas/placeholder/quadros/IDhere
+
 ###[{"TextoInterno":"texto1"},{"TextoInterno":"texto2"},{"TextoInterno":"texto3"}]
 ###
 
 GET {{PushIt_HostAddress}}/canvas/placeholder
 Accept: application/json
-
-###
-
-###DELETE {{PushIt_HostAddress}}/canvas/placeholder
 
 ###

--- a/server/src/PushIt/Services/CanvasService.cs
+++ b/server/src/PushIt/Services/CanvasService.cs
@@ -53,4 +53,13 @@ public class CanvasService : ICanvasService
         this.canvasPseudoDatabase[canvasName].UpdateQuadro(quadro!.id, novoQuadro);
         return true;
     }
+
+    public bool DeleteQuadro(string canvasName, string quadroId)
+    {
+        if(!this.canvasPseudoDatabase.ContainsKey(canvasName)){ return false; }
+        if(!this.canvasPseudoDatabase[canvasName].HasQuadro(quadroId, out _)){ return false; }
+
+        this.canvasPseudoDatabase[canvasName].DeleteQuadro(quadroId);
+        return true;
+    }
 }

--- a/server/src/PushIt/Services/ICanvasService.cs
+++ b/server/src/PushIt/Services/ICanvasService.cs
@@ -6,4 +6,5 @@ public interface ICanvasService
     public QuadroAnotacao? GetQuadro(string canvasName, string quadroId);
     public List<QuadroAnotacao> GetAllQuadros(string canvasName);
     public bool UpdateQuadro(string canvasName, string quadroId, QuadroAnotacao novoQuadro);
+    public bool DeleteQuadro(string canvasName, string quadroId);
 }


### PR DESCRIPTION
Implementação de um endpoint DELETE para possibilitar remover quadros específicos de um canvas existente.

Requisição:
DELETE /canvas/{nomeDoCanvas}/quadros/{IDdoQuadro}
Em casos bem sucedidos retorna uma response 204 - NoContent

Resumo Modificações:
Implementação de um novo endpoint DELETE em CanvasController
Implementação de 1 nova função em Canvas e CanvasService