### PR TITLE
Frontend-RF005-Alterar as posições dos quadros de anotações

### DIFF
--- a/client/src/components/StickyNotes/StickyNote.jsx
+++ b/client/src/components/StickyNotes/StickyNote.jsx
@@ -39,18 +39,19 @@ export function StickyNote({
             onTextClick(!isEditing);
         }
     }
-
+    //Função de começo de movimento que tambem sairá modo de edição quando ativado
     function handleStartDragging() {
         setIsDragging(true);
         setIsEditing(false);
     }
-
+    //Função de fim de movimento do quadro.
     function handleStopDragging() {
         setIsDragging(false);
     }
 
     // Formatação do Quadro de anotações agrupado em dois retangulos e um quadro de texto
     return(
+        //Inicialização do agrupamento com parametros de movimentação
         <Group x={x} y={y} draggable={true} onDragStart={handleStartDragging} onDragEnd={handleStopDragging}>
             {/*Retangulo visual*/}
             <Rect

--- a/client/src/components/StickyNotes/StickyNote.jsx
+++ b/client/src/components/StickyNotes/StickyNote.jsx
@@ -23,6 +23,7 @@ export function StickyNote({
 
     //Verificar estado de edição do quadro de anotações
     const [isEditing, setIsEditing] = useState(false);
+    const [isDragging, setIsDragging] = useState(false);
 
     //Efeito para desativar edição quando o quadro não estiver selecionado
     useEffect(() => {
@@ -33,13 +34,24 @@ export function StickyNote({
 
     // Mudança no estado de edição
     function toggleEdit() {
-        setIsEditing(!isEditing);
-        onTextClick(!isEditing);
+        if(!isDragging){
+            setIsEditing(!isEditing);
+            onTextClick(!isEditing);
+        }
+    }
+
+    function handleStartDragging() {
+        setIsDragging(true);
+        setIsEditing(false);
+    }
+
+    function handleStopDragging() {
+        setIsDragging(false);
     }
 
     // Formatação do Quadro de anotações agrupado em dois retangulos e um quadro de texto
     return(
-        <Group x={x} y={y}>
+        <Group x={x} y={y} draggable={true} onDragStart={handleStartDragging} onDragEnd={handleStopDragging}>
             {/*Retangulo visual*/}
             <Rect
                 x={20}

--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -13,8 +13,8 @@ function CanvasPage(){
     const addSticky = () => {
         const newSticky = {
             id: Date.now(), // ID unico de criação
-            x: Math.random() * (window.innerWidth - 100), //Posição aleatoria
-            y: Math.random() * (window.innerHeight - 100), //Posição aleatoria
+            x: 20, //Posição aleatoria
+            y: 20, //Posição aleatoria
             width: 250, // Largura do sticky
             height: 230, // Altura do sticky
             text: "Insira seu texto!!", // Texto default


### PR DESCRIPTION
- Alteração no arquivo StickyNote.jsx para que o **Group** do framework do quadro de anotações se torne movimentavel ao segurar o quadro com o mouse.

- Geração do quadro de anotações agora é fixo ao ser gerado dentro do canva.

- Não é possivel editar o texto do quadro enquanto fizer a sua movimentação.