### PR TITLE
Frontend - RF004 - Alterar tamanho do quadro de anotações

### DIFF
--- a/client/src/components/StickyNotes/EditTextInput.jsx
+++ b/client/src/components/StickyNotes/EditTextInput.jsx
@@ -8,8 +8,8 @@ function setStyle(width,height) {
     const isFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
     //Base para o estilo do textarea
     const baseStyle = {
-        width: `${width}px`,
-        height: `${height}px`,
+        width: `${width - 10}px`,
+        height: `${height - 10}px`,
         border: "none",
         padding: "5px",
         margin: "0px",

--- a/client/src/components/StickyNotes/StickyNote.jsx
+++ b/client/src/components/StickyNotes/StickyNote.jsx
@@ -30,6 +30,11 @@ export function StickyNote({
     const groupRef = useRef(null);
     const transformerRef = useRef(null);
 
+    //Inicialização dos tamanhos maximos dos quadros
+    const defaultMaxWidth = 1000;
+    const defaultMaxHeight = 900;
+
+
     //Efeito para desativar edição quando o quadro não estiver selecionado
     useEffect(() => {
         if(!selected && isEditing) {
@@ -38,6 +43,7 @@ export function StickyNote({
     }, [selected, isEditing]);
 
     //Efeito para Transformar um <Stickynote>
+    //Ele irá selecionar o agrupamento do framework do sticky e fara referencia ao Transformer
     useEffect(() => {
         if(selected && transformerRef.current && groupRef.current){
             transformerRef.current.nodes([groupRef.current]);
@@ -73,8 +79,8 @@ export function StickyNote({
         node.scaleY(1);
 
         //Calculo das novas dimensões do quadro
-        const newWidth = Math.max(100, width * scaleX);
-        const newHeight = Math.max(100, height * scaleY);
+        const newWidth = Math.max(100, Math.min(defaultMaxWidth, width * scaleX));
+        const newHeight = Math.max(100, Math.min(defaultMaxHeight, height * scaleY));
 
         //Callback com o dimensionamento novo
         onResize(newWidth, newHeight);
@@ -84,7 +90,7 @@ export function StickyNote({
     // Formatação do Quadro de anotações agrupado em dois retangulos e um quadro de texto
     return(
         <>
-            {/*Inicialização do agrupamento com parametros de movimentação*/}
+            {/*Inicialização do agrupamento com parametros de movimentação e click*/}
             <Group 
                 x={x} 
                 y={y} 
@@ -96,7 +102,7 @@ export function StickyNote({
                 ref={groupRef}
                 onTransform={handleTransform}
             >
-                {/*Retangulo visual*/}
+                {/*Retangulo visual 1*/}
                 <Rect
                     x={20}
                     y={20}
@@ -110,7 +116,7 @@ export function StickyNote({
                     shadowOpacity={0.6}
                     perfectDrawEnabled={false}
                 />
-                {/*Retangulo de interação*/}
+                {/*Retangulo visual 2*/}
                 <Rect
                     x={0}
                     y={0}

--- a/client/src/components/StickyNotes/StickyNote.jsx
+++ b/client/src/components/StickyNotes/StickyNote.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Group, Rect, Transformer } from "react-konva";
 import { EditText } from "./EditText";
 
@@ -37,8 +37,9 @@ export function StickyNote({
         }
     }, [selected, isEditing]);
 
+    //Efeito para Transformar um <Stickynote>
     useEffect(() => {
-        if(selected && tranformerRef.current && groupRef.current){
+        if(selected && transformerRef.current && groupRef.current){
             transformerRef.current.nodes([groupRef.current]);
             transformerRef.current.getLayer().batchDraw();
         }
@@ -61,19 +62,21 @@ export function StickyNote({
         setIsDragging(false);
     }
 
+    //Função de redimensionamento dos quadros
     function handleTransform(e) {
         const node = groupRef.current;
         const scaleX = node.scaleX();
         const scaleY = node.scaleY();
 
-
+        //Resetar escalas para evitar bugs
         node.scaleX(1);
         node.scaleY(1);
 
-        
+        //Calculo das novas dimensões do quadro
         const newWidth = Math.max(100, width * scaleX);
         const newHeight = Math.max(100, height * scaleY);
 
+        //Callback com o dimensionamento novo
         OnResize(newWidth, newHeight);
 
     }

--- a/client/src/components/StickyNotes/StickyNote.jsx
+++ b/client/src/components/StickyNotes/StickyNote.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Group, Rect } from "react-konva";
+import { Group, Rect, Transformer } from "react-konva";
 import { EditText } from "./EditText";
 
 
@@ -18,12 +18,17 @@ export function StickyNote({
     onClick, // Estado
     selected, // Booleano
     onTextChange, // Estado
-    onTextClick // Estado
+    onTextClick, // Estado
+    OnResize // Estado
 }) {
 
     //Verificar estado de edição do quadro de anotações
     const [isEditing, setIsEditing] = useState(false);
     const [isDragging, setIsDragging] = useState(false);
+
+    //Variaveis de referencia para redimensionamento dos quadros
+    const groupRef = useRef(null);
+    const transformerRef = useRef(null);
 
     //Efeito para desativar edição quando o quadro não estiver selecionado
     useEffect(() => {
@@ -31,6 +36,13 @@ export function StickyNote({
             setIsEditing(false);
         }
     }, [selected, isEditing]);
+
+    useEffect(() => {
+        if(selected && tranformerRef.current && groupRef.current){
+            transformerRef.current.nodes([groupRef.current]);
+            transformerRef.current.getLayer().batchDraw();
+        }
+    }, [selected])
 
     // Mudança no estado de edição
     function toggleEdit() {
@@ -49,46 +61,84 @@ export function StickyNote({
         setIsDragging(false);
     }
 
+    function handleTransform(e) {
+        const node = groupRef.current;
+        const scaleX = node.scaleX();
+        const scaleY = node.scaleY();
+
+
+        node.scaleX(1);
+        node.scaleY(1);
+
+        
+        const newWidth = Math.max(100, width * scaleX);
+        const newHeight = Math.max(100, height * scaleY);
+
+        OnResize(newWidth, newHeight);
+
+    }
+
     // Formatação do Quadro de anotações agrupado em dois retangulos e um quadro de texto
     return(
-        //Inicialização do agrupamento com parametros de movimentação
-        <Group x={x} y={y} draggable={true} onDragStart={handleStartDragging} onDragEnd={handleStopDragging}>
-            {/*Retangulo visual*/}
-            <Rect
-                x={20}
-                y={20}
-                width={width}
-                height={height + 40}
-                fill={colour}
-                shadowColor="black"
-                shadowOffsetX={0}
-                shadowOffsetY={10}
-                shadowBlur={30}
-                shadowOpacity={0.6}
-                perfectDrawEnabled={false}
-            />
-            {/*Retangulo de interação*/}
-            <Rect
-                x={0}
-                y={0}
-                width={width + 40}
-                height={height + 60}
-                fill={colour}
-                perfectDrawEnabled={false}
+        <>
+            {/*Inicialização do agrupamento com parametros de movimentação*/}
+            <Group 
+                x={x} 
+                y={y} 
+                draggable={true} 
+                onDragStart={handleStartDragging} 
+                onDragEnd={handleStopDragging}
                 onClick={onClick}
                 onTap={onClick}
-            />
-            {/*Componente para visualização,edição do texto*/}
-            <EditText
-                x={20}
-                y={20}
-                text={text}
-                width={width}
-                height={height + 40}
-                isEditing={isEditing}
-                onToggleEdit={toggleEdit}
-                onChange={onTextChange}
-            />
-        </Group>
-    )
+                ref={groupRef}
+                onTransform={handleTransform}
+            >
+                {/*Retangulo visual*/}
+                <Rect
+                    x={20}
+                    y={20}
+                    width={width}
+                    height={height + 40}
+                    fill={colour}
+                    shadowColor="black"
+                    shadowOffsetX={0}
+                    shadowOffsetY={10}
+                    shadowBlur={30}
+                    shadowOpacity={0.6}
+                    perfectDrawEnabled={false}
+                />
+                {/*Retangulo de interação*/}
+                <Rect
+                    x={0}
+                    y={0}
+                    width={width + 40}
+                    height={height + 60}
+                    fill={colour}
+                    perfectDrawEnabled={false}
+                />
+                {/*Componente para visualização,edição do texto*/}
+                <EditText
+                    x={20}
+                    y={20}
+                    text={text}
+                    width={width}
+                    height={height + 40}
+                    isEditing={isEditing}
+                    onToggleEdit={toggleEdit}
+                    onChange={onTextChange}
+                />
+            </Group>
+            {selected && !isEditing && (
+                <Transformer
+                    ref={transformerRef}
+                    boundBoxFunc={(oldBox, newBox) => {
+                        if(newBox.width < 100 || newBox.height < 100) {
+                            return oldBox;
+                        }
+                        return oldBox;
+                    }}
+                />
+            )}
+        </>
+    );
 }

--- a/client/src/components/StickyNotes/StickyNote.jsx
+++ b/client/src/components/StickyNotes/StickyNote.jsx
@@ -19,7 +19,7 @@ export function StickyNote({
     selected, // Booleano
     onTextChange, // Estado
     onTextClick, // Estado
-    OnResize // Estado
+    onResize // Estado
 }) {
 
     //Verificar estado de edição do quadro de anotações
@@ -63,7 +63,7 @@ export function StickyNote({
     }
 
     //Função de redimensionamento dos quadros
-    function handleTransform(e) {
+    function handleTransform() {
         const node = groupRef.current;
         const scaleX = node.scaleX();
         const scaleY = node.scaleY();
@@ -77,7 +77,7 @@ export function StickyNote({
         const newHeight = Math.max(100, height * scaleY);
 
         //Callback com o dimensionamento novo
-        OnResize(newWidth, newHeight);
+        onResize(newWidth, newHeight);
 
     }
 
@@ -88,7 +88,7 @@ export function StickyNote({
             <Group 
                 x={x} 
                 y={y} 
-                draggable={true} 
+                draggable={!isEditing} 
                 onDragStart={handleStartDragging} 
                 onDragEnd={handleStopDragging}
                 onClick={onClick}
@@ -131,6 +131,8 @@ export function StickyNote({
                     onChange={onTextChange}
                 />
             </Group>
+
+            {/*Transformer de redimensionamento*/}
             {selected && !isEditing && (
                 <Transformer
                     ref={transformerRef}
@@ -138,7 +140,7 @@ export function StickyNote({
                         if(newBox.width < 100 || newBox.height < 100) {
                             return oldBox;
                         }
-                        return oldBox;
+                        return newBox;
                     }}
                 />
             )}

--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -73,9 +73,9 @@ function CanvasPage(){
                                 )
                             );
                         }}
-                        //Mantem o texto dentro do quadro de anotações 
-                        // no qual possa ter um texto fora do escopo da margem
-                        onTextResize={(newWidth, newHeight) => {
+                        //Este escopo possui o serviço de redimensionamento do
+                        // quadro de acordo com as preferencias do usuario
+                        onResize={(newWidth, newHeight) => {
                             setStickyNotes(
                                 stickyNotes.map(n =>
                                     n.id === objectNode.id ? { ...n, width: newWidth, height: newHeight } : n


### PR DESCRIPTION
- Importação do metodo Transformer do 'react-konva' para realizar a mudança de redimensionamento dos quadros de anotações.
- Refatoração do framework do Quadro de anotações
- Ajuste no texto do quadro de anotações para que ele se torne responsivel junto com o redimensionamento do quadro.
- Aplicado um limite para o tamanho maximo de redimensionamento de um quadro.