### PR TITLE
Frontend-RF010-Alterar cor de quadro de anotação e de sua fonte

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "react": "^19.1.0",
+        "react-colorful": "^5.6.1",
         "react-dom": "^19.1.0",
         "react-konva": "^19.0.3",
         "react-konva-utils": "^1.1.0",
@@ -13849,6 +13850,16 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT"
+    },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "react": "^19.1.0",
+    "react-colorful": "^5.6.1",
     "react-dom": "^19.1.0",
     "react-konva": "^19.0.3",
     "react-konva-utils": "^1.1.0",

--- a/client/src/components/StickyNotes/EditText.jsx
+++ b/client/src/components/StickyNotes/EditText.jsx
@@ -16,6 +16,7 @@ export function EditText({
     onToggleEdit,
     onChange,
     text,
+    fontColour,
     width,
     height
 }) {
@@ -51,6 +52,7 @@ export function EditText({
         y={y}
         onDoubleClick={onToggleEdit}
         text={text}
+        fontColour={fontColour}
         width={width}
         height={height}
     />

--- a/client/src/components/StickyNotes/ResizableText.jsx
+++ b/client/src/components/StickyNotes/ResizableText.jsx
@@ -8,6 +8,7 @@ export function ResizableText({
     x, // Posição
     y, // Posição
     text, // Texto
+    fontColour, // Cor do texto
     width, // Largura
     height, // Altura
     onDoubleClick // evento
@@ -19,7 +20,7 @@ export function ResizableText({
             x={x}
             y={y}
             text={text}
-            fill="black"
+            fill={fontColour}
             fontFamily="sans-serif"
             fontSize={24}
             perfectDrawEnabled={false}

--- a/client/src/components/StickyNotes/StickyNote.jsx
+++ b/client/src/components/StickyNotes/StickyNote.jsx
@@ -9,8 +9,9 @@ import { EditText } from "./EditText";
 //PARAMETROS PARA A INICIALIZAÇÃO DO QUADRO DE ANOTAÇÃO
 export function StickyNote({
     id, // Identificação do sticky
-    text, // Eexto
+    text, // Texto
     colour, //Selecionar cor
+    fontColour,
     x, //Posição
     y, //Posição
     width, //Largura
@@ -27,7 +28,7 @@ export function StickyNote({
     const [isDragging, setIsDragging] = useState(false);
 
 
-        //Variaveis de referencia para redimensionamento dos quadros
+    //Variaveis de referencia para redimensionamento dos quadros
     const groupRef = useRef(null);
     const transformerRef = useRef(null);
 
@@ -103,7 +104,7 @@ export function StickyNote({
                 ref={groupRef}
                 onTransform={handleTransform}
             >
-                {/*Retangulo visual 1*/}
+            {/*Retangulo visual 1*/}
             <Rect
                 x={20}
                 y={20}
@@ -138,10 +139,11 @@ export function StickyNote({
                 isEditing={isEditing}
                 onToggleEdit={toggleEdit}
                 onChange={onTextChange}
+                fontColour={fontColour}
             />
         </Group>
 
-                    {/*Transformer de redimensionamento*/}
+            {/*Transformer de redimensionamento*/}
             {selected && !isEditing && (
                 <Transformer
                     ref={transformerRef}

--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -26,6 +26,8 @@ function CanvasPage(){
         setStickyNotes([...stickyNotes,newSticky])
     };
 
+    const selectedSticky = stickyNotes.find(note => note.selected);
+
     //Lógica para ativar o modo de exclusão através de um botão
     //realizando a deleção de um stickynote especifico ao click
     //Estado de exclusão
@@ -35,7 +37,7 @@ function CanvasPage(){
     function toggleDelete(){
         setDeleteMode(!deleteMode);
         setStickyNotes(stickyNotes.map(nodes => ({ ...nodes, selected: false})));
-        setColorfulPick({ ...colorfulPick, PalletOpened: false});
+        setColorfulPick({ ...colorfulPick, palledOpened: false});
     };
 
     //Deletará um stickynode
@@ -43,30 +45,58 @@ function CanvasPage(){
         setStickyNotes(stickyNotes.filter(node => node.id !== id));
     };
 
+
     //Logica para mudança de cores de um quadro de anotações
     //usando react-colorful para a melhor experiencia de usuario
 
     //variavel terá 3 estados, no qual verá se a paleta está aberta, o id do sticky e a cor atual
     const [ colorfulPick, setColorfulPick ] = useState({
-        PalletOpened: false, stickyID: null, currentColour: stickyNotes.colour 
+        palledOpened: false, stickyID: null, currentColour: stickyNotes.colour 
     });
 
     const togglePallet = (id,colour) => {
         setColorfulPick({
-            PalletOpened: !colorfulPick.PalletOpened,
+            palledOpened: !colorfulPick.palledOpened,
             stickyID: id,
             currentColour: colour
         })
     }
 
-    //Atualiza para a nova cor das stickies 
-    const updatePalletSticky = (id, newColour) => {
+    //Atualiza para a nova cor das stickies selecionadas
+    const updatePalletSticky = (newColour) => {
         setStickyNotes(prev =>
             prev.map(note => 
                 note.selected ? { ...note, colour: newColour } : note
             )
         );
     };
+
+
+    //Logica para aplicar mudança de cor na fonte dos Quadros
+    //Terá que ser feita na mesma branch do RF010, 
+    // pois usuario poderá mudar para uma cor que não torne a fonte atual visivel
+
+    const [ fontColorfulPick, setFontColorfulPick ] = useState({
+        fontPalletOpened: false, fontStickyID: null, fontCurrentColour: "#000000"
+    });
+
+        const toggleFontPallet = (id,fontColour) => {
+        setFontColorfulPick({
+            fontPalletOpened: !fontColorfulPick.fontPalletOpened,
+            fontStickyID: id,
+            fontCurrentColour: fontColour
+        })
+    }
+
+    //Atualiza para a nova cor da font das stickies selecionadas 
+    const updateFontPalletSticky = (newFontColour) => {
+        setStickyNotes(prev =>
+            prev.map(note => 
+                note.selected ? { ...note, fontColour: newFontColour } : note
+            )
+        );
+    };
+
 
     //Função para selecionar mais de um stickynote quando pressionar o SHIFT
 
@@ -96,12 +126,12 @@ function CanvasPage(){
     //Ajusta o bug no qual deixa a peleta aberta apos todos os quadros serem deselecionados usando o SHIFT
     useEffect(() => {
         const anySelectioned = stickyNotes.some(note => note.selected);
-        if(!anySelectioned && colorfulPick.PalletOpened){
-            setColorfulPick({ ...colorfulPick, PalletOpened: false })
+        if(!anySelectioned && colorfulPick.palledOpened){
+            setColorfulPick({ ...colorfulPick, palledOpened: false })
         }
     },[colorfulPick,stickyNotes]);
 
-    const selectedSticky = stickyNotes.find(note => note.selected);
+    
 
     //TODO: Redimensionar o <Stage> automaticamente com o React para evitar bug de resolução
 
@@ -112,25 +142,39 @@ function CanvasPage(){
                 <button className="canvaspage_button" onClick={addSticky}>Adicionar Quadro</button>
                 <button className="canvaspage_button" onClick={toggleDelete}>{deleteMode ? "Sair do modo de deleção" : "Excluir Quadro"}</button>
                 {selectedSticky && !deleteMode && (
+                    <>
                     <button 
-                        className="canvaspage-button"  
+                        className="canvaspage_button"  
                         onClick={() => togglePallet(selectedSticky.id, selectedSticky.colour)}
                     >
-                        {colorfulPick.PalletOpened && colorfulPick.stickyID === selectedSticky.id
+                        {colorfulPick.palledOpened && colorfulPick.stickyID === selectedSticky.id
                             ? "Fechar Paleta"
-                            : "Mudar de cor"
+                            : "Mudar de cor do quadro"
                         }
                     </button>
+                    <button
+                        className="canvaspage_button"
+                        onClick={() => toggleFontPallet(selectedSticky.id, selectedSticky.colour)}
+                    >
+                        {fontColorfulPick.fontPalletOpened && fontColorfulPick.fontStickyID === selectedSticky.id
+                            ? "Fechar Paleta"
+                            : "Mudar de cor da fonte"
+                        }
+                    </button>
+
+                    </>
                 )}
+
             </div>
-            {/*Função de pagina para mudançade cor dos stickies*/}
-            {colorfulPick.PalletOpened && (
+            {/*Função de pagina para mudança de cor dos stickies*/}
+            {colorfulPick.palledOpened && (
                 <div className="colorful-model">
                     <div className="colorful-content" onClick={(e) => e.stopPropagation()}>
                         <h3 className="canvaspage_h3">Escolha uma cor</h3>
                         <HexColorPicker
+                            className="colorful-palletpicker"
                             color={colorfulPick.currentColour}
-                            onChange={(newColour) => updatePalletSticky(colorfulPick.stickyID, newColour)}
+                            onChange={(newColour) => updatePalletSticky(newColour)}
                         />
                         <input
                         className="canvaspage_input"
@@ -138,10 +182,33 @@ function CanvasPage(){
                             value={colorfulPick.currentColour}
                             onChange={(e) => {
                                 const newColour = e.target.value;
-                                updatePalletSticky(colorfulPick.stickyID, newColour);
+                                updatePalletSticky(newColour);
                                 setColorfulPick({ ...colorfulPick, currentColour: newColour});
                             }}
                             placeholder={colorfulPick.currentColour}
+                        />
+                    </div>
+                </div>
+            )}
+            {fontColorfulPick.fontPalletOpened && (
+                <div className="colorful-model">
+                    <div className="colorful-content" onClick={(e) => e.stopPropagation}>
+                        <h3 className="canvaspage_h3">Escolha uma cor</h3>
+                        <HexColorPicker
+                            className="colorful-palletpicker"
+                            color={fontColorfulPick.fontCurrentColour}
+                            onChange={(changeFontColour) => updateFontPalletSticky(changeFontColour)}
+                        />
+                        <input
+                            className="canvaspage_input"
+                            type="text"
+                            value={fontColorfulPick.fontCurrentColour}
+                            onChange={(e) => {
+                                const inputNewFontColour = e.target.value;
+                                updateFontPalletSticky(fontColorfulPick.fontStickyID, inputNewFontColour)
+                                setFontColorfulPick({ ...fontColorfulPick, fontCurrentColour: inputNewFontColour});
+                            }}
+                            placeholder="#000000"
                         />
                     </div>
                 </div>
@@ -152,8 +219,9 @@ function CanvasPage(){
                 //Função evento para deseleciona todas stickynotes do canvas
                 onClick={(e) => {
                     if(e.currentTarget._id ===  e.target._id){
-                        setStickyNotes(stickyNotes.map(note => ({ ...note, selected: false})))
-                        setColorfulPick({ ...colorfulPick, PalletOpened: false });
+                        setStickyNotes(stickyNotes.map(note => ({ ...note, selected: false})));
+                        setColorfulPick({ ...colorfulPick, palledOpened: false });
+                        setFontColorfulPick({ ...fontColorfulPick, fontPalletOpened: false});
                     }
                 }}
             >

--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -73,6 +73,7 @@ function CanvasPage(){
     const [ pressedShift, setPressedShift ] = useState(false);
 
     useEffect(() => {
+
         function handleShiftDown(e) {
             if(e.key === "Shift") {
                 setPressedShift(true);
@@ -89,10 +90,16 @@ function CanvasPage(){
             window.removeEventListener("keydown", handleShiftDown);
             window.removeEventListener("keyup", handleShiftUp);
         };
+
     }, []);
 
-
-
+    //Ajusta o bug no qual deixa a peleta aberta apos todos os quadros serem deselecionados usando o SHIFT
+    useEffect(() => {
+        const anySelectioned = stickyNotes.some(note => note.selected);
+        if(!anySelectioned && colorfulPick.PalletOpened){
+            setColorfulPick({ ...colorfulPick, PalletOpened: false })
+        }
+    },[colorfulPick,stickyNotes]);
 
     const selectedSticky = stickyNotes.find(note => note.selected);
 
@@ -120,12 +127,13 @@ function CanvasPage(){
             {colorfulPick.PalletOpened && (
                 <div className="colorful-model">
                     <div className="colorful-content" onClick={(e) => e.stopPropagation()}>
-                        <h3>Escolha uma cor</h3>
+                        <h3 className="canvaspage_h3">Escolha uma cor</h3>
                         <HexColorPicker
                             color={colorfulPick.currentColour}
                             onChange={(newColour) => updatePalletSticky(colorfulPick.stickyID, newColour)}
                         />
                         <input
+                        className="canvaspage_input"
                             type="text"
                             value={colorfulPick.currentColour}
                             onChange={(e) => {

--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Stage, Layer} from 'react-konva'
 import { StickyNote } from "../components/StickyNotes/StickyNote";
 import { HexColorPicker } from "react-colorful"
@@ -61,12 +61,38 @@ function CanvasPage(){
 
     //Atualiza para a nova cor das stickies 
     const updatePalletSticky = (id, newColour) => {
-        setStickyNotes(
-            stickyNotes.map(note => 
-                note.id === id ? { ...note, colour: newColour,selected: true } : note
+        setStickyNotes(prev =>
+            prev.map(note => 
+                note.selected ? { ...note, colour: newColour } : note
             )
         );
     };
+
+    //Função para selecionar mais de um stickynote quando pressionar o SHIFT
+
+    const [ pressedShift, setPressedShift ] = useState(false);
+
+    useEffect(() => {
+        function handleShiftDown(e) {
+            if(e.key === "Shift") {
+                setPressedShift(true);
+            }
+        }
+        function handleShiftUp(e) {
+            if(e.key === "Shift") {
+                setPressedShift(false);
+            }
+        }
+        window.addEventListener("keydown", handleShiftDown);
+        window.addEventListener("keyup", handleShiftUp);
+        return () => {
+            window.removeEventListener("keydown", handleShiftDown);
+            window.removeEventListener("keyup", handleShiftUp);
+        };
+    }, []);
+
+
+
 
     const selectedSticky = stickyNotes.find(note => note.selected);
 
@@ -135,11 +161,17 @@ function CanvasPage(){
                             if(deleteMode){
                                 deleteStickyNode(objectNode.id);
                             }else{
-                            setStickyNotes(
-                                stickyNotes.map(n =>
-                                    n.id === objectNode.id ? { ...n, selected: !n.selected } : { ...n, selected: false }
-                                )
-                            );
+                                setStickyNotes(prev =>
+                                    prev.map(node => {
+                                        if(node.id === objectNode.id) {
+                                            return { ...node, selected: !node.selected };
+                                        }else if(pressedShift){
+                                            return node;
+                                        }else{
+                                            return { ...node, selected: false};
+                                        }
+                                    })
+                                );
                             }
                         }}
                         //Atualiza o texto no quadro selecionado

--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Stage, Layer} from 'react-konva'
 import { StickyNote } from "../components/StickyNotes/StickyNote";
+import { HexColorPicker } from "react-colorful"
 
 function CanvasPage(){
 
@@ -19,7 +20,7 @@ function CanvasPage(){
             height: 230, // Altura do sticky
             text: "Insira seu texto!!", // Texto default
             selected: false, // Estado de seleção inicial
-            colour: "Yellow" // Cor do sticky
+            colour: colorfulPick.currentColour // Cor do sticky de acordo com as funções de cores
         };
         //Adiciona a nova sticky no array
         setStickyNotes([...stickyNotes,newSticky])
@@ -46,26 +47,28 @@ function CanvasPage(){
 
     //variavel terá 3 estados, no qual verá se a paleta está aberta, o id do sticky e a cor atual
     const [ colorfulPick, setColorfulPick ] = useState({
-        PalletOpenned: false, stickyID: null, currentColour: "#FFFF00" 
+        PalletOpened: false, stickyID: null, currentColour: "#FFFF00" 
     });
 
-    const openPallet = (stickyID, currentColour) =>{
-        setColorfulPick({ PalletOpenned: true, stickyID, currentColour });
+    const togglePallet = (id,colour) => {
+        setColorfulPick({
+            PalletOpened: !colorfulPick.PalletOpened,
+            stickyID: id,
+            currentColour: colour
+        })
     }
 
-    const closedPallet = () => {
-        setColorfulPick({ ...colorfulPick, PalletOpenned: false });
-    }
-
+    //Atualiza para a nova cor das stickies 
     const updatePalletSticky = (id, newColour) => {
         setStickyNotes(
             stickyNotes.map(note => 
-                note.id === id ? { ...note, colour: newColour } : note
+                note.id === id ? { ...note, colour: newColour,selected: true } : note
             )
         );
         setColorfulPick({ ...colorfulPick, currentColour: newColour });
     };
 
+    const selectedSticky = stickyNotes.find(note => note.selected);
 
     //TODO: Redimensionar o <Stage> automaticamente com o React para evitar bug de resolução
 
@@ -75,7 +78,30 @@ function CanvasPage(){
             <div className="canvaspage_div_buttons">
                 <button className="canvaspage_button" onClick={addSticky}>Adicionar Quadro</button>
                 <button className="canvaspage_button" onClick={toggleDelete}>{deleteMode ? "Sair do modo de deleção" : "Excluir Quadro"}</button>
+                {selectedSticky && !deleteMode && (
+                    <button 
+                        className="canvaspage-button"  
+                        onClick={() => togglePallet(selectedSticky.id, selectedSticky.colour)}
+                    >
+                        {colorfulPick.PalletOpened && colorfulPick.stickyID === selectedSticky.id
+                            ? "Fechar Paleta"
+                            : "Mudar de cor"
+                        }
+                    </button>
+                )}
             </div>
+            {/*Função de pagina para mudançade cor dos stickies*/}
+            {colorfulPick.PalletOpened && (
+                <div className="colorful-model">
+                    <div className="colorful-content">
+                        <h3>Escolha uma cor</h3>
+                        <HexColorPicker
+                            color={colorfulPick.currentColour}
+                            onChange={(newColour) => updatePalletSticky(colorfulPick.stickyID, newColour)}
+                        />
+                    </div>
+                </div>
+            )}
             <Stage 
                 width={window.innerWidth} 
                 height={window.innerHeight}

--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -38,6 +38,7 @@ function CanvasPage(){
         setDeleteMode(!deleteMode);
         setStickyNotes(stickyNotes.map(nodes => ({ ...nodes, selected: false})));
         setColorfulPick({ ...colorfulPick, palledOpened: false});
+        setFontColorfulPick({ ...fontColorfulPick, fontPalletOpened: false})
     };
 
     //Deletará um stickynode
@@ -60,6 +61,7 @@ function CanvasPage(){
             stickyID: id,
             currentColour: colour
         })
+        setFontColorfulPick({ ...fontColorfulPick, fontPalletOpened:false });
     }
 
     //Atualiza para a nova cor das stickies selecionadas
@@ -86,6 +88,7 @@ function CanvasPage(){
             fontStickyID: id,
             fontCurrentColour: fontColour
         })
+        setColorfulPick({ ...colorfulPick, palledOpened:false });
     }
 
     //Atualiza para a nova cor da font das stickies selecionadas 
@@ -170,11 +173,14 @@ function CanvasPage(){
             {colorfulPick.palledOpened && (
                 <div className="colorful-model">
                     <div className="colorful-content" onClick={(e) => e.stopPropagation()}>
-                        <h3 className="canvaspage_h3">Escolha uma cor</h3>
+                        <h3 className="canvaspage_h3">Cor para o Pushit</h3>
                         <HexColorPicker
                             className="colorful-palletpicker"
                             color={colorfulPick.currentColour}
-                            onChange={(newColour) => updatePalletSticky(newColour)}
+                            onChange={(newColour) => {
+                                setColorfulPick({ ...colorfulPick, currentColour: newColour});
+                                updatePalletSticky(newColour)
+                            }}
                         />
                         <input
                         className="canvaspage_input"
@@ -193,11 +199,14 @@ function CanvasPage(){
             {fontColorfulPick.fontPalletOpened && (
                 <div className="colorful-model">
                     <div className="colorful-content" onClick={(e) => e.stopPropagation}>
-                        <h3 className="canvaspage_h3">Escolha uma cor</h3>
+                        <h3 className="canvaspage_h3">Cor para a fonte</h3>
                         <HexColorPicker
                             className="colorful-palletpicker"
                             color={fontColorfulPick.fontCurrentColour}
-                            onChange={(changeFontColour) => updateFontPalletSticky(changeFontColour)}
+                            onChange={(changeFontColour) => {
+                                setFontColorfulPick({ ...fontColorfulPick, fontCurrentColour: changeFontColour});
+                                updateFontPalletSticky(changeFontColour)
+                            }}
                         />
                         <input
                             className="canvaspage_input"

--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -41,6 +41,31 @@ function CanvasPage(){
         setStickyNotes(stickyNotes.filter(node => node.id !== id));
     };
 
+    //Logica para mudança de cores de um quadro de anotações
+    //usando react-colorful para a melhor experiencia de usuario
+
+    //variavel terá 3 estados, no qual verá se a paleta está aberta, o id do sticky e a cor atual
+    const [ colorfulPick, setColorfulPick ] = useState({
+        PalletOpenned: false, stickyID: null, currentColour: "#FFFF00" 
+    });
+
+    const openPallet = (stickyID, currentColour) =>{
+        setColorfulPick({ PalletOpenned: true, stickyID, currentColour });
+    }
+
+    const closedPallet = () => {
+        setColorfulPick({ ...colorfulPick, PalletOpenned: false });
+    }
+
+    const updatePalletSticky = (id, newColour) => {
+        setStickyNotes(
+            stickyNotes.map(note => 
+                note.id === id ? { ...note, colour: newColour } : note
+            )
+        );
+        setColorfulPick({ ...colorfulPick, currentColour: newColour });
+    };
+
 
     //TODO: Redimensionar o <Stage> automaticamente com o React para evitar bug de resolução
 

--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -20,7 +20,7 @@ function CanvasPage(){
             height: 230, // Altura do sticky
             text: "Insira seu texto!!", // Texto default
             selected: false, // Estado de seleção inicial
-            colour: colorfulPick.currentColour // Cor do sticky de acordo com as funções de cores
+            colour: "#FFFF00" // Cor do sticky de acordo com as funções de cores
         };
         //Adiciona a nova sticky no array
         setStickyNotes([...stickyNotes,newSticky])
@@ -35,6 +35,7 @@ function CanvasPage(){
     function toggleDelete(){
         setDeleteMode(!deleteMode);
         setStickyNotes(stickyNotes.map(nodes => ({ ...nodes, selected: false})));
+        setColorfulPick({ ...colorfulPick, PalletOpened: false});
     };
 
     //Deletará um stickynode
@@ -47,7 +48,7 @@ function CanvasPage(){
 
     //variavel terá 3 estados, no qual verá se a paleta está aberta, o id do sticky e a cor atual
     const [ colorfulPick, setColorfulPick ] = useState({
-        PalletOpened: false, stickyID: null, currentColour: "#FFFF00" 
+        PalletOpened: false, stickyID: null, currentColour: stickyNotes.colour 
     });
 
     const togglePallet = (id,colour) => {
@@ -65,7 +66,6 @@ function CanvasPage(){
                 note.id === id ? { ...note, colour: newColour,selected: true } : note
             )
         );
-        setColorfulPick({ ...colorfulPick, currentColour: newColour });
     };
 
     const selectedSticky = stickyNotes.find(note => note.selected);
@@ -93,11 +93,21 @@ function CanvasPage(){
             {/*Função de pagina para mudançade cor dos stickies*/}
             {colorfulPick.PalletOpened && (
                 <div className="colorful-model">
-                    <div className="colorful-content">
+                    <div className="colorful-content" onClick={(e) => e.stopPropagation()}>
                         <h3>Escolha uma cor</h3>
                         <HexColorPicker
                             color={colorfulPick.currentColour}
                             onChange={(newColour) => updatePalletSticky(colorfulPick.stickyID, newColour)}
+                        />
+                        <input
+                            type="text"
+                            value={colorfulPick.currentColour}
+                            onChange={(e) => {
+                                const newColour = e.target.value;
+                                updatePalletSticky(colorfulPick.stickyID, newColour);
+                                setColorfulPick({ ...colorfulPick, currentColour: newColour});
+                            }}
+                            placeholder={colorfulPick.currentColour}
                         />
                     </div>
                 </div>
@@ -109,6 +119,7 @@ function CanvasPage(){
                 onClick={(e) => {
                     if(e.currentTarget._id ===  e.target._id){
                         setStickyNotes(stickyNotes.map(note => ({ ...note, selected: false})))
+                        setColorfulPick({ ...colorfulPick, PalletOpened: false });
                     }
                 }}
             >

--- a/client/src/styles/Pages.css
+++ b/client/src/styles/Pages.css
@@ -120,3 +120,21 @@ body {
   height: 40px;
   font-size: 16px;
 }
+/*Estilo para o Pallet dos stickynotes*/
+.colorful-model {
+  position: fixed;
+  top: 0;
+  left: 160px;
+  width: 100%;
+  height: 100%;
+  z-index: 100;
+}
+
+.colorful-content {
+  padding: 20px;
+  border-radius: 8px;
+  gap: 15px;
+  align-items: center;
+  max-width: 300px;
+  width: 100%;
+}

--- a/client/src/styles/Pages.css
+++ b/client/src/styles/Pages.css
@@ -118,9 +118,10 @@ body {
   font-family: "Coiny", system-ui;
 }
 .canvaspage_input{
+  max-width: 200px;
   text-align: center;
-  border-radius: 3vmin;
   font-family: "Coiny", system-ui;
+  font-size: 16px;
 }
 .canvaspage_button {
   position: relative;
@@ -131,8 +132,8 @@ body {
 /*Estilo para o Pallet dos stickynotes*/
 .colorful-model {
   position: fixed;
-  top: 10%;
-  left: 10%;
+  top: 100px;
+  left: 150px;
   width: 100%;
   height: 100%;
   z-index: 11;
@@ -149,4 +150,19 @@ body {
   width: 100%;
   z-index: 11;
   pointer-events: auto;
+}
+
+.colorful-palletpicker {
+  width: 200px;
+  height: 200px;
+}
+
+.colorful-palletpicker  .react-colorful__hue {
+  height: 30px;
+  border-radius: 4px;
+}
+
+.colorful-palletpicker  .react-colorful__pointer {
+  width: 26px;
+  height: 26px;
 }

--- a/client/src/styles/Pages.css
+++ b/client/src/styles/Pages.css
@@ -114,6 +114,14 @@ body {
   gap: 10px;
   z-index: 10;
 }
+.canvaspage_h3{
+  font-family: "Coiny", system-ui;
+}
+.canvaspage_input{
+  text-align: center;
+  border-radius: 3vmin;
+  font-family: "Coiny", system-ui;
+}
 .canvaspage_button {
   position: relative;
   width: 120px;
@@ -129,7 +137,7 @@ body {
   height: 100%;
   z-index: 11;
   background-color: transparent;
-  pointer-events: auto;
+  pointer-events: none;
 }
 
 .colorful-content {
@@ -140,4 +148,5 @@ body {
   max-width: 300px;
   width: 100%;
   z-index: 11;
+  pointer-events: auto;
 }

--- a/client/src/styles/Pages.css
+++ b/client/src/styles/Pages.css
@@ -123,11 +123,13 @@ body {
 /*Estilo para o Pallet dos stickynotes*/
 .colorful-model {
   position: fixed;
-  top: 0;
-  left: 160px;
+  top: 10%;
+  left: 10%;
   width: 100%;
   height: 100%;
-  z-index: 100;
+  z-index: 11;
+  background-color: transparent;
+  pointer-events: auto;
 }
 
 .colorful-content {
@@ -137,4 +139,5 @@ body {
   align-items: center;
   max-width: 300px;
   width: 100%;
+  z-index: 11;
 }


### PR DESCRIPTION
=====Mudança de cor no quadro de anotações=====
- Nesta adição de funcionalidade foi acrescentado o pacote 'react-colorful' que adiciona uma paleta de cores para o usuario decidir que cor usar para o seu quadro.

- Nesta logica, o usuario deve agora selecionar o quadro no qual ele deseja fazer a alteração de cor, podendo ser um ou mais quadros.

- Toda essa mudança pode ser feita após o usuario selecionar no minimo um quadro, assim tornará o botão para mudar a cor do quadro visivel.

- Foi dado a liberdade ao usuario decidir, caso saiba a cor que deseje usar com base no codigo hexadecimal, alterar a cor dos quadros.

=====Mudança de cor na fonte do quadro de anotações=====

- Tendo em vista que, com base na cor que o usuario decidir alterar para o seu quadro, o texto dentro do mesmo pode se tornar dificil de visualizar, então foi adicionadas novas funções para alterar as cores das fontes dos quadros.

- A logica da mudança de cor no quadro de anotações e da fonte do quadro, funcionam da mesma maneira.

- Foi acrescentada novas variaveis no framework do Stickynote sendo elas: StickyNote.jsx,EditText.jsx e ResizableText.jsx para realizar a alteração da cor do texto.

====Função extra====
- O usuario agora pode selecionar mais de um quadro de anotações ao segurar a tecla 'SHIFT'.

=====Observação=====
- Os botões de deleção,mudança de cor do quadro e mudança de cor da fonte, representam MODOS, então quando um é ativado, o outro irá se desativar, sendo assim, não é possivel você deletar e mudar a cor de um quadro ao mesmo tempo.
