### PR TITLE
Frontend-RF009-Exportar canvas em arquivo de imagem

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "html2canvas": "^1.4.1",
         "react": "^19.1.0",
         "react-colorful": "^5.6.1",
         "react-dom": "^19.1.0",
@@ -5189,6 +5190,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -6059,6 +6069,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-loader": {
@@ -9016,6 +9035,19 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/htmlparser2": {
@@ -16245,6 +16277,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -16777,6 +16818,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "html2canvas": "^1.4.1",
     "react": "^19.1.0",
     "react-colorful": "^5.6.1",
     "react-dom": "^19.1.0",

--- a/client/src/components/screenshot/screenshot.js
+++ b/client/src/components/screenshot/screenshot.js
@@ -1,7 +1,13 @@
 import html2canvas from "html2canvas";
 
-export function takeScreenShot(div, nomeDoArquivoString) {
-    const element = document.getElementById(div);
+
+/**
+ * @param {string} id - O ID do elemento HTML que será capturado.
+ * @param {string} nomeDoArquivo - O nome do arquivo PNG que será salvo.
+ */
+
+export function takeScreenShot(id, nomeDoArquivo) {
+    const element = document.getElementById(id);
     if(!element) {
         console.log("Não foi possivel identificar o elemento.");
         return;
@@ -12,7 +18,7 @@ export function takeScreenShot(div, nomeDoArquivoString) {
         const dataURL = canvas.toDataURL("image/png");
         const link = document.createElement("a");
         link.href = dataURL;
-        link.download = nomeDoArquivoString;
+        link.download = nomeDoArquivo;
         link.click();
     });
 }

--- a/client/src/components/screenshot/screenshot.js
+++ b/client/src/components/screenshot/screenshot.js
@@ -1,0 +1,18 @@
+import html2canvas from "html2canvas";
+
+export function takeScreenShot(div, nomeDoArquivoString) {
+    const element = document.getElementById(div);
+    if(!element) {
+        console.log("Não foi possivel identificar o elemento.");
+        return;
+    }
+
+
+    html2canvas(element).then(canvas => {
+        const dataURL = canvas.toDataURL("image/png");
+        const link = document.createElement("a");
+        link.href = dataURL;
+        link.download = nomeDoArquivoString;
+        link.click();
+    });
+}

--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Stage, Layer} from 'react-konva'
 import { StickyNote } from "../components/StickyNotes/StickyNote";
 import { HexColorPicker } from "react-colorful"
+import { takeScreenShot } from "../components/screenshot/screenshot";
 
 function CanvasPage(){
 
@@ -139,9 +140,10 @@ function CanvasPage(){
     //TODO: Redimensionar o <Stage> automaticamente com o React para evitar bug de resolução
 
     return(
-        <main className="canvaspage_main">
+        <main className="canvaspage_main" id ="canvaspage_main">
             {/* Botão que adiciona novo sticky para renderizar*/}
             <div className="canvaspage_div_buttons">
+                <button className="canvaspage_button" onClick={() => takeScreenShot("canvaspage_main","canvasPrint.png")}>Tirar foto</button>
                 <button className="canvaspage_button" onClick={addSticky}>Adicionar Quadro</button>
                 <button className="canvaspage_button" onClick={toggleDelete}>{deleteMode ? "Sair do modo de deleção" : "Excluir Quadro"}</button>
                 {selectedSticky && !deleteMode && (


### PR DESCRIPTION
- Foi adicionado um novo pacote chamado 'html2canvas', que tratará de encapsular todo o DOM e exportar para arquivos de imagem.
- Acrescentado uma nova pasta '\screenshot' no '\components', com um arquivo screenshot.js que terá o algoritmo para realizar os prints da pagina.
- Adicionado um novo botão na pagina para o usuario tirar foto do seu canvas.