### PR TITLE
Frontend-RF011-Adicionar conexão entre anotações

### DIFF
--- a/client/src/components/StickyNotes/StickyNote.jsx
+++ b/client/src/components/StickyNotes/StickyNote.jsx
@@ -59,8 +59,8 @@ export function StickyNote({
     // Mudança no estado de edição
     function toggleEdit() {
         if(!isDragging){
-            setIsEditing(!isEditing);
-            onTextClick(!isEditing);
+            setIsEditing(true);
+            onTextClick(true);
         }
     }
     //Função de começo de movimento que tambem sairá modo de edição quando ativado

--- a/client/src/components/StickyNotes/StickyNote.jsx
+++ b/client/src/components/StickyNotes/StickyNote.jsx
@@ -20,7 +20,10 @@ export function StickyNote({
     selected, // Booleano
     onTextChange, // Estado
     onTextClick, // Estado
-    onResize // Estado
+    onResize, // Estado
+    onDragEnd, // Estado
+    onDragMove, // Estado
+    idConnect // Vetor
 }) {
 
     //Verificar estado de edição do quadro de anotações
@@ -61,13 +64,14 @@ export function StickyNote({
         }
     }
     //Função de começo de movimento que tambem sairá modo de edição quando ativado
-    function handleStartDragging() {
+    const handleStartDragging = () => {
         setIsDragging(true);
         setIsEditing(false);
     }
     //Função de fim de movimento do quadro.
-    function handleStopDragging() {
+    const handleStopDragging = (e) => {
         setIsDragging(false);
+        onDragEnd(e.target.x(), e.target.y());
     }
 
         //Função de redimensionamento dos quadros
@@ -99,6 +103,9 @@ export function StickyNote({
                 draggable={!isEditing} 
                 onDragStart={handleStartDragging} 
                 onDragEnd={handleStopDragging}
+                onDragMove={(e) => {
+                    onDragMove?.(e);
+                }}
                 onClick={onClick}
                 onTap={onClick}
                 ref={groupRef}

--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -21,8 +21,8 @@ function CanvasPage(){
             height: 230, // Altura do sticky
             text: "Insira seu texto!!", // Texto default
             selected: false, // Estado de seleção inicial
-            colour: "#FFFF00", // Cor do sticky de acordo com as funções de cores
-            fontColour: "#000000",
+            colour: colorfulPick.currentColour, // Cor do sticky de acordo com as funções de cores
+            fontColour: fontColorfulPick.fontCurrentColour,
             idConnect: [] // Array de conexões do sticky
         };
         //Adiciona a nova sticky no array
@@ -43,6 +43,7 @@ function CanvasPage(){
         setColorfulPick({ ...colorfulPick, palletOpened: false});
         setFontColorfulPick({ ...fontColorfulPick, fontPalletOpened: false})
         setConnectMode(false)
+        setSelectMain(null);
     };
 
     //Deletará um stickynode
@@ -56,25 +57,26 @@ function CanvasPage(){
 
     //variavel terá 3 estados, no qual verá se a paleta está aberta, o id do sticky e a cor atual
     const [ colorfulPick, setColorfulPick ] = useState({
-        palletOpened: false, stickyID: null, currentColour: stickyNotes.colour 
+        palletOpened: false, stickyID: null, currentColour: "#FFFF00"
     });
 
     const togglePallet = (id,colour) => {
         setColorfulPick({
             palletOpened: !colorfulPick.palletOpened,
             stickyID: id,
-            currentColour: colour
+            currentColour: colour || "#FFFF00"
         })
         setFontColorfulPick({ ...fontColorfulPick, fontPalletOpened:false });
     }
 
     //Atualiza para a nova cor das stickies selecionadas
     const updatePalletSticky = (newColour) => {
-        setStickyNotes(prev =>
-            prev.map(note => 
+        setStickyNotes((prev) =>
+            prev.map((note) =>
                 note.selected ? { ...note, colour: newColour } : note
             )
         );
+        setColorfulPick({ ...colorfulPick, currentColour: newColour });
     };
 
 
@@ -90,18 +92,20 @@ function CanvasPage(){
         setFontColorfulPick({
             fontPalletOpened: !fontColorfulPick.fontPalletOpened,
             fontStickyID: id,
-            fontCurrentColour: fontColour
+            fontCurrentColour: fontColour || "#000000"
         })
-        setColorfulPick({ ...colorfulPick, palletOpened:false });
+        setColorfulPick({ ...colorfulPick, palletOpened: false });
     }
 
     //Atualiza para a nova cor da font das stickies selecionadas 
     const updateFontPalletSticky = (newFontColour) => {
-        setStickyNotes(prev =>
-            prev.map(note => 
+        setStickyNotes((prev) =>
+            prev.map((note) =>
                 note.selected ? { ...note, fontColour: newFontColour } : note
             )
         );
+        setFontColorfulPick({...fontColorfulPick,fontCurrentColour: newFontColour,});
+        
     };
 
 
@@ -155,9 +159,10 @@ function CanvasPage(){
     const toggleConnect = () => {
         setConnectMode(!connectMode)
         setDeleteMode(false)
+        setSelectMain(null);
         setStickyNotes(stickyNotes.map((node) => ({ ...node, selected:false })));
         setColorfulPick({ ...colorfulPick, palletOpened: false });
-        setFontColorfulPick({ ...fontColorfulPick, fontCurrentColour: false});
+        setFontColorfulPick({ ...fontColorfulPick, fontPalletOpened: false});
     }
 
     const handleSelectConnect = (id) => {
@@ -297,7 +302,7 @@ function CanvasPage(){
                 //Função evento para deseleciona todas stickynotes do canvas
                 onClick={(e) => {
                     if(e.currentTarget._id ===  e.target._id){
-                        setStickyNotes(stickyNotes.map(note => ({ ...note, selected: false})));
+                        setStickyNotes(stickyNotes.map((note) => ({ ...note, selected: false})));
                         setColorfulPick({ ...colorfulPick, palletOpened: false });
                         setFontColorfulPick({ ...fontColorfulPick, fontPalletOpened: false});
                         setConnectMode(false);

--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState,useRef } from "react";
-import { Stage, Layer, Arrow} from 'react-konva'
+import { Stage, Layer, Line} from 'react-konva'
 import { StickyNote } from "../components/StickyNotes/StickyNote";
 import { HexColorPicker } from "react-colorful"
 import { takeScreenShot } from "../components/screenshot/screenshot";
@@ -310,7 +310,7 @@ function CanvasPage(){
                     {connections.map((connectId, index) => {
                         const intersect = createArrowPos(connectId.fromId, connectId.toId);
                         return (
-                            <Arrow
+                            <Line
                                 key={`arrow-${index}`}
                                 points={intersect}
                                 stroke={"#000000"}


### PR DESCRIPTION
Foi feita a implementação das conexões entre as anotações usando o item 'Line' do 'react-konva'.

- Reestruturado Stickynote.jsx para realizar a implementação das conexões.
- Aplicado a logica de conexões entre cada anotação, onde agora na pagina tera um botão de conexão no qual, o usuario irá clicar nele e depois nos dois quadros que ele deseja realizar a conexão.
- Ajuste de alguns possiveis futuros e presentes bugs.