### PR TITLE
Frontend-RF012-Remover conexão entre anotações

### DIFF
--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -152,6 +152,7 @@ function CanvasPage(){
         const toId = stickyNotes.find((node) => node.id === idSecond);
         if(!fromId || !toId) return[0,0,0,0];
 
+        //Calculo do posicionamento da seta
         const mainX = fromId.x + fromId.width / 2 + 20;
         const mainY = fromId.y + fromId.height / 2 + 30;
         const secondX = toId.x + toId.width / 2 + 20;
@@ -236,10 +237,12 @@ function CanvasPage(){
 
     //Verifica se tem conexão os quadros selecionados
 
+    //Verifica em todos
     const verifyConnAny = selectedSticky.length > 0 && selectedSticky.some((note) =>
         connections.some((conn) => conn.fromId === note.id || conn.toId === note.id)
     );
 
+    //Verifica em conexões de 2 quadros em especifico
     const verifyConnTwo = selectedSticky.length === 2 && (() => {
         const [ firstId,secondId ] = selectedSticky.map((note) => note.id);
         return connections.some(

--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -146,6 +146,7 @@ function CanvasPage(){
     const [ selectMain, setSelectMain ] = useState(null);
     const arrowsLayer = useRef(null);
 
+    //Arranja as linhas para conexão
     const createArrowPos = (idMain, idSecond) => {
         const fromId = stickyNotes.find((node) => node.id === idMain);
         const toId = stickyNotes.find((node) => node.id === idSecond);
@@ -160,6 +161,7 @@ function CanvasPage(){
 
     }
 
+    //Ativa a o modo de conexão
     const toggleConnect = () => {
         setConnectMode(!connectMode)
         setDeleteMode(false)
@@ -169,6 +171,7 @@ function CanvasPage(){
         setFontColorfulPick({ ...fontColorfulPick, fontPalletOpened: false});
     }
 
+    //Seleciona as conexões escolidas pelo usuario
     const handleSelectConnect = (id) => {
         if(connectMode) {
             if(!selectMain) {
@@ -204,6 +207,7 @@ function CanvasPage(){
 
     // Logica para a remoção das conexões dentre os quadros
 
+    //Ao selecionar um quadro, todas as conexões com ele são removidas
     const removeConnectionAll = () => {
         if(selectedSticky.length === 0) return;
         const selectedId = selectedSticky.map((note) => note.id);
@@ -213,6 +217,7 @@ function CanvasPage(){
         }
     };
 
+    // Ao selecionar dois quadros, a conexão entre eles é removida
     const removeConnectionSpecific = () => {
         if (selectedSticky.length === 0) return;
 

--- a/client/src/pages/canvasPage.jsx
+++ b/client/src/pages/canvasPage.jsx
@@ -198,6 +198,28 @@ function CanvasPage(){
         }
     };
 
+    // Logica para a remoção das conexões dentre os quadros
+
+    const removeConnection = () => {
+        if (selectedSticky.length === 0) return;
+
+        const selectIds = selectedSticky.map((note) => note.id);
+        setConnections(
+            connections.filter(
+                (conn) => !selectIds.includes(conn.fromId) && !selectIds.includes(conn.toId)
+            )
+        );
+        if(arrowsLayer.current){
+            arrowsLayer.current.batchDraw();
+        }
+    };
+
+    //Verifica se tem conexão os quadros selecionados
+
+    const verifyConn = selectedSticky.some((note) =>
+        connections.some((conn) => conn.fromId === note.id || conn.toId === note.id)
+    );
+
     //TODO: Redimensionar o <Stage> automaticamente com o React para evitar bug de resolução
 
     
@@ -238,7 +260,9 @@ function CanvasPage(){
                             : "Mudar de cor da fonte"
                         }
                     </button>
-
+                    {verifyConn && (
+                        <button className="canvaspage_button" onClick={removeConnection}>Remover Conexão</button>
+                    )}
                     </>
                 )}
 


### PR DESCRIPTION
- Foi aplicada a logica de remoção de conexão no canvasPage.jsx.
- O usuario agora pode remover a conexão de varias conexões de um quadro.
- O usuario agora pode remover a conexão de dois quadros especificos de acordo com a sua seleção.
- Ambas ações podem ser feitas através de dois botões adicionais na pagina