### PR TITLE
Backend-RF012_e_AlteracaoRF011-adicionar/remover seta conexao

### DIFF
--- a/server/src/PushIt/Controllers/CanvasController.cs
+++ b/server/src/PushIt/Controllers/CanvasController.cs
@@ -25,7 +25,7 @@ public class CanvasController : ControllerBase
 
         // Aqui salva na database ou lista em memória
         canvas = await this._canvasService.CreateCanvasAsync(canvas);
-        if(canvas is null)
+        if (canvas is null)
         {
             return BadRequest();
         }
@@ -77,7 +77,7 @@ public class CanvasController : ControllerBase
     public async Task<IActionResult> GetQuadroAsync(string name, string id)
     {
         QuadroAnotacao? quadro = await this._canvasService.GetQuadroAsync(name, id);
-        if(quadro is null)
+        if (quadro is null)
         {
             return NotFound();
         }
@@ -108,7 +108,7 @@ public class CanvasController : ControllerBase
     {
         QuadroAnotacao quadro = request.ToQuadro(id);
         bool successful = await this._canvasService.TryUpdateQuadroAsync(name, id, quadro);
-        
+
         if (!successful)
         {
             return NotFound();
@@ -137,16 +137,21 @@ public class CanvasController : ControllerBase
     {
         QuadroAnotacao? quadro = await this._canvasService.GetQuadroAsync(name, LocalId);
 
-        if(quadro is null){ return NotFound(); }
+        if (quadro is null) { return NotFound(); }
 
         GetAllQuadroConexoesResponse response = new(quadro.IDsConectados ?? new());
         return Ok(response);
     }
+    
+    //GET /canvas/{CanvasName}/quadros/{LocalId}/conexoes/{IdConexao}
+    [HttpDelete("/canvas/{CanvasName}/quadros/{LocalId}/conexoes/{IdConexao}")]
+    public async Task<IActionResult> DeleteQuadroConexaoAsync(string CanvasName, string LocalId, string IdConexao)
+    {
+        bool successful = await this._canvasService.TryDeleteQuadroConexaoAsync(CanvasName, LocalId, IdConexao);
 
-    // [HttpDelete("/canvas/{name}/quadros/{id}/conexoes/{IdDeletar}")]
-    // public IActionResult DeleteConexao(string name, string id, string IdDeletar)
-    // {
-    //     return Ok();
-    // }
+        if(!successful){ return NotFound(); }
+
+        return NoContent();
+    }
 
 }

--- a/server/src/PushIt/Controllers/CanvasController.cs
+++ b/server/src/PushIt/Controllers/CanvasController.cs
@@ -131,6 +131,20 @@ public class CanvasController : ControllerBase
         return NoContent();
     }
 
+    //POST /canvas/{CanvasName}/quadros/{LocalId}/conexoes
+    [HttpPost("/CanvasName/{CanvasName}/quadros/{LocalId}/conexoes")]
+    public async Task<IActionResult> CreateQuadroConexaoAsync(string CanvasName, string LocalId, CreateQuadroConexaoRequest request)
+    {
+        List<string>? IDsConectados = await this._canvasService.CreateQuadroConexaoAsync(CanvasName, LocalId, request.IdQuadroDestino);
+
+        if (IDsConectados is null) { return BadRequest(); }
+
+        GetAllQuadroConexoesResponse response = new(IDsConectados);
+        return CreatedAtAction("GetAllQuadroConexoes",
+                                new {name = CanvasName, LocalId = LocalId},
+                                response);
+    }
+
     //GET /canvas/{nomecanvas}/quadros/{iddoquadro}/conexoes
     [HttpGet("/canvas/{name}/quadros/{LocalId}/conexoes")]
     public async Task<IActionResult> GetAllQuadroConexoesAsync(string name, string LocalId)
@@ -143,7 +157,7 @@ public class CanvasController : ControllerBase
         return Ok(response);
     }
     
-    //GET /canvas/{CanvasName}/quadros/{LocalId}/conexoes/{IdConexao}
+    //DELETE /canvas/{CanvasName}/quadros/{LocalId}/conexoes/{IdConexao}
     [HttpDelete("/canvas/{CanvasName}/quadros/{LocalId}/conexoes/{IdConexao}")]
     public async Task<IActionResult> DeleteQuadroConexaoAsync(string CanvasName, string LocalId, string IdConexao)
     {

--- a/server/src/PushIt/Controllers/CanvasController.cs
+++ b/server/src/PushIt/Controllers/CanvasController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
 
 [ApiController]
 //[Route("canvas")]
@@ -132,7 +133,7 @@ public class CanvasController : ControllerBase
     }
 
     //POST /canvas/{CanvasName}/quadros/{LocalId}/conexoes
-    [HttpPost("/CanvasName/{CanvasName}/quadros/{LocalId}/conexoes")]
+    [HttpPost("/canvas/{CanvasName}/quadros/{LocalId}/conexoes")]
     public async Task<IActionResult> CreateQuadroConexaoAsync(string CanvasName, string LocalId, CreateQuadroConexaoRequest request)
     {
         List<string>? IDsConectados = await this._canvasService.CreateQuadroConexaoAsync(CanvasName, LocalId, request.IdQuadroDestino);
@@ -140,16 +141,17 @@ public class CanvasController : ControllerBase
         if (IDsConectados is null) { return BadRequest(); }
 
         GetAllQuadroConexoesResponse response = new(IDsConectados);
+
         return CreatedAtAction("GetAllQuadroConexoes",
-                                new {name = CanvasName, LocalId = LocalId},
+                                new { CanvasName = CanvasName, LocalId = LocalId },
                                 response);
     }
 
     //GET /canvas/{nomecanvas}/quadros/{iddoquadro}/conexoes
-    [HttpGet("/canvas/{name}/quadros/{LocalId}/conexoes")]
-    public async Task<IActionResult> GetAllQuadroConexoesAsync(string name, string LocalId)
+    [HttpGet("/canvas/{CanvasName}/quadros/{LocalId}/conexoes")]
+    public async Task<IActionResult> GetAllQuadroConexoesAsync(string CanvasName, string LocalId)
     {
-        QuadroAnotacao? quadro = await this._canvasService.GetQuadroAsync(name, LocalId);
+        QuadroAnotacao? quadro = await this._canvasService.GetQuadroAsync(CanvasName, LocalId);
 
         if (quadro is null) { return NotFound(); }
 

--- a/server/src/PushIt/DTOs_Contracts/Requests/CreateCanvasRequest.cs
+++ b/server/src/PushIt/DTOs_Contracts/Requests/CreateCanvasRequest.cs
@@ -1,6 +1,6 @@
 public record CreateCanvasRequest
 (
     string Name,
-    List<QuadroAnotacao> QuadrosAnotacoes,
+    //List<QuadroAnotacao> QuadrosAnotacoes,
     DateTime CreatedDateTime
 );

--- a/server/src/PushIt/DTOs_Contracts/Requests/CreateQuadroConexaoRequest.cs
+++ b/server/src/PushIt/DTOs_Contracts/Requests/CreateQuadroConexaoRequest.cs
@@ -1,0 +1,3 @@
+public record CreateQuadroConexaoRequest(
+    string IdQuadroDestino
+);

--- a/server/src/PushIt/DTOs_Contracts/Requests/UpdateQuadroRequest.cs
+++ b/server/src/PushIt/DTOs_Contracts/Requests/UpdateQuadroRequest.cs
@@ -5,6 +5,6 @@ public record UpdateQuadroRequest
      double width,
      double height,
      string text,
-     string colour,
-     List<string> IDsConectados
+     string colour
+     //List<string> IDsConectados
 );

--- a/server/src/PushIt/Mapping/CanvasMapping.cs
+++ b/server/src/PushIt/Mapping/CanvasMapping.cs
@@ -4,7 +4,7 @@ public static class CanvasMapping
     {
         return new Canvas(
             name: request.Name,
-            quadrosAnotacoes: request.QuadrosAnotacoes ?? new(),
+            quadrosAnotacoes: new(),
             createdDateTime: request.CreatedDateTime,
             lastModification: DateTime.Now
         );

--- a/server/src/PushIt/Mapping/QuadrosMapping.cs
+++ b/server/src/PushIt/Mapping/QuadrosMapping.cs
@@ -26,7 +26,7 @@ public static class QuadrosMapping
             height: request.height,
             text: request.text,
             colour: request.colour,
-            IDsConectados: request.IDsConectados,
+            IDsConectados: default,
 
             lastModification: DateTime.Now
         );
@@ -60,7 +60,7 @@ public static class QuadrosMapping
             height: quadroAnotacao.height,
             text: quadroAnotacao.text,
             colour: quadroAnotacao.colour,
-            IDsConectados: quadroAnotacao.IDsConectados,
+            IDsConectados: quadroAnotacao.IDsConectados ?? new(),
             lastModification: quadroAnotacao.LastModification
         );
     }

--- a/server/src/PushIt/Models/QuadroAnotacao.cs
+++ b/server/src/PushIt/Models/QuadroAnotacao.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-[Table("QuadroAnotacao")]
 public class QuadroAnotacao
 {
     public const string defaultText = "";
@@ -16,12 +15,11 @@ public class QuadroAnotacao
     public string colour { get; }
 
     //Obter Através de query "SELECT *" na tabela Quadro_Aponta_Quadro
-    [Column("QuadrosApontados'")]
-    public List<string> IDsConectados { get; }
+    public List<string>? IDsConectados { get; }
 
     public DateTime LastModification { get; }
     
-    public QuadroAnotacao(string id, double x, double y, double width, double height, string text, string colour, List<string> IDsConectados, DateTime lastModification)
+    public QuadroAnotacao(string id, double x, double y, double width, double height, string text, string colour, List<string>? IDsConectados, DateTime lastModification)
     {
         this.id = id;
         this.x = x;

--- a/server/src/PushIt/Requests/PushIt.http
+++ b/server/src/PushIt/Requests/PushIt.http
@@ -1,9 +1,9 @@
 ###Variáveis para facilitar a estruturação de Requisições
 @PushIt_HostAddress = http://localhost:5176
 @NomeCanvas = Validação Teste
-@ID_Quadro = 12
+@ID_Quadro = 1
 
-@IdQuadroDestino = 123
+@ID_QuadroDestino = 1
 
 
 ### Criar Canvas
@@ -21,7 +21,7 @@ POST {{PushIt_HostAddress}}/canvas/{{NomeCanvas}}/quadros
 Content-Type: application/json
 
 {
-    "id":"1234",
+    "id":"1",
     "x":1.0,
     "y":1.0,
     "width":33,
@@ -41,7 +41,7 @@ Content-Type: application/json
     "width":66,
     "height":66,
     "text":"66",
-    "colour":"#01450",  
+    "colour":"#01450"  
 }
 
 
@@ -70,13 +70,14 @@ Accept: application/json
 
 ### Criar uma Seta de conexão entre dois quadros de um Canvas
 ### Inserir no URI o ID do Quadro de onde começa a seta, e inserir no JSON da request o ID para onde a Seta Aponta
+
 POST {{PushIt_HostAddress}}/canvas/{{NomeCanvas}}/quadros/{{ID_Quadro}}/conexoes
 Content-Type: application/json
 
 {
-    "IdQuadroDestino":"123456"  
+    "IdQuadroDestino":"1ss"
 }
 
 
 ### Deletar uma Seta de conexão
-DELETE {{PushIt_HostAddress}}/canvas/{{NomeCanvas}}/quadros/{{ID_Quadro}}/conexoes/{{IdQuadroDestino}}
+DELETE {{PushIt_HostAddress}}/canvas/{{NomeCanvas}}/quadros/{{ID_Quadro}}/conexoes/{{ID_QuadroDestino}}

--- a/server/src/PushIt/Requests/PushIt.http
+++ b/server/src/PushIt/Requests/PushIt.http
@@ -3,6 +3,8 @@
 @NomeCanvas = Validação Teste
 @ID_Quadro = 12
 
+@IdQuadroDestino = 123
+
 
 ### Criar Canvas
 POST {{PushIt_HostAddress}}/canvas
@@ -10,7 +12,6 @@ Content-Type: application/json
 
 {
     "Name":"Validação Teste",
-    "QuadrosAnotacoes": [ ],
     "CreatedDateTime":"2025-04-22T15:00:00"
 }
 
@@ -41,7 +42,6 @@ Content-Type: application/json
     "height":66,
     "text":"66",
     "colour":"#01450",  
-    "IDsConectados": []
 }
 
 
@@ -68,4 +68,15 @@ Accept: application/json
 GET {{PushIt_HostAddress}}/canvas/{{NomeCanvas}}/quadros/{{ID_Quadro}}/conexoes
 Accept: application/json
 
-###
+### Criar uma Seta de conexão entre dois quadros de um Canvas
+### Inserir no URI o ID do Quadro de onde começa a seta, e inserir no JSON da request o ID para onde a Seta Aponta
+POST {{PushIt_HostAddress}}/canvas/{{NomeCanvas}}/quadros/{{ID_Quadro}}/conexoes
+Content-Type: application/json
+
+{
+    "IdQuadroDestino":"123456"  
+}
+
+
+### Deletar uma Seta de conexão
+DELETE {{PushIt_HostAddress}}/canvas/{{NomeCanvas}}/quadros/{{ID_Quadro}}/conexoes/{{IdQuadroDestino}}

--- a/server/src/PushIt/Services/CanvasService.cs
+++ b/server/src/PushIt/Services/CanvasService.cs
@@ -182,6 +182,11 @@ public class CanvasService : ICanvasService
                                                                     entry.localIdQuadroDestino == localIdQuadroDestino);
         if (conexaoQuery is not null) { return null; }
 
+        //Cria uma nova entry e adiciona na Database
+        Quadro_Aponta_Quadro novaConexao = new(quadroQuery.quadro, localIdQuadroDestino);
+        await dbContext.conexoes.AddAsync(novaConexao);
+        await dbContext.SaveChangesAsync();
+
         List<string> IDsConectados = await (from entry in dbContext.conexoes
                                             where entry.QuadroComeco.id == quadroQuery.quadro.id
                                             select entry.localIdQuadroDestino)

--- a/server/src/PushIt/Services/CanvasService.cs
+++ b/server/src/PushIt/Services/CanvasService.cs
@@ -134,27 +134,13 @@ public class CanvasService : ICanvasService
 
         //atualiza a entrada da Tabela Quadros
         QuadrosEntity? quadroEntity = await dbContext.quadros.FindAsync(canvasQuadro.quadro.id);
-        quadroEntity!.x = novoQuadro.x;
-        quadroEntity.y = novoQuadro.y;
-        quadroEntity.width = novoQuadro.width;
-        quadroEntity.height = novoQuadro.height;
-        quadroEntity.text = novoQuadro.text;
-        quadroEntity.colour = novoQuadro.colour;
-        quadroEntity.LastModification = novoQuadro.LastModification;
-        await dbContext.SaveChangesAsync();
-
-        quadroEntity = await dbContext.quadros.FindAsync(canvasQuadro.quadro.id);
-
-        //deleta todas as entradas de conexão relacionadas ao Quadro a ser Atualizado na tabela Quadro_Aponta_Quadro
-        await dbContext.conexoes.Where(c => c.QuadroComeco.id == canvasQuadro.quadro.id).ExecuteDeleteAsync();
-
-        //Adiciona todas as conexões novamente de acordo com o estado atual do Quadro
-        foreach (string IDConectado in novoQuadro.IDsConectados)
-        {
-            var quadroApontaQuadroEntity = new Quadro_Aponta_Quadro(quadroEntity!, IDConectado);
-            await dbContext.conexoes.AddAsync(quadroApontaQuadroEntity);
-        }
-
+            quadroEntity!.x = novoQuadro.x;
+            quadroEntity.y = novoQuadro.y;
+            quadroEntity.width = novoQuadro.width;
+            quadroEntity.height = novoQuadro.height;
+            quadroEntity.text = novoQuadro.text;
+            quadroEntity.colour = novoQuadro.colour;
+            quadroEntity.LastModification = novoQuadro.LastModification;
         await dbContext.SaveChangesAsync();
 
         return true;
@@ -216,7 +202,8 @@ public class CanvasService : ICanvasService
         if (quadroQuery is null) { return false; }
 
         await dbContext.conexoes.Where(entry => entry.QuadroComeco.id == quadroQuery!.quadro.id &&
-                                       entry.localIdQuadroDestino == idConexao).ExecuteDeleteAsync();
+                                       entry.localIdQuadroDestino == idConexao)
+                                       .ExecuteDeleteAsync();
 
 
         return true;

--- a/server/src/PushIt/Services/ICanvasService.cs
+++ b/server/src/PushIt/Services/ICanvasService.cs
@@ -7,4 +7,5 @@ public interface ICanvasService
     public Task<List<QuadroAnotacao>?> GetAllQuadrosAsync(string canvasName);
     public Task<bool> TryUpdateQuadroAsync(string canvasName, string quadroLocalId, QuadroAnotacao novoQuadro);
     public Task<bool> TryDeleteQuadroAsync(string canvasName, string quadroId);
+    public Task<bool> TryDeleteQuadroConexaoAsync(string canvasName, string localId, string idConexao);
 }

--- a/server/src/PushIt/Services/ICanvasService.cs
+++ b/server/src/PushIt/Services/ICanvasService.cs
@@ -7,5 +7,6 @@ public interface ICanvasService
     public Task<List<QuadroAnotacao>?> GetAllQuadrosAsync(string canvasName);
     public Task<bool> TryUpdateQuadroAsync(string canvasName, string quadroLocalId, QuadroAnotacao novoQuadro);
     public Task<bool> TryDeleteQuadroAsync(string canvasName, string quadroId);
+    public Task<List<string>?> CreateQuadroConexaoAsync(string CanvasName, string quadroLocalId, string IdQuadroDestino);
     public Task<bool> TryDeleteQuadroConexaoAsync(string canvasName, string localId, string idConexao);
 }


### PR DESCRIPTION
Implementação de 2 endpoints novos:

POST conexao entre quadros de anotação
{{PushIt_HostAddress}}/canvas/{{NomeCanvas}}/quadros/{{ID_Quadro}}/conexoes

DELETE conexao de um quadro de anotação
{{PushIt_HostAddress}}/canvas/{{NomeCanvas}}/quadros/{{ID_Quadro}}/conexoes/{{ID_QuadroDestino}}

=-=-=-=-=-=-=-=-=-=-=

Alteração da lógica do endpoint PUT quadro de anotação:
Agora ele NÃO interage nem modifica a lista de conexões de Quadros de Anotações presentes no Banco de Dados

=-=-=-=-=-=-=-=-=-=-=

Alteração dos DTOs de Request 
-Remoção da propriedade List<QuadroAnotacao> do DTO de CreateCanvasRequest (POST canvas), visto que um canvas recém criado sempre começa vazio
-Remoção da propriedade List<strings> (IDsConectados) do DTO de UpdateQuadroRequest (PUT quadro), a fim de otimizar processos internos do backend
