### PR TITLE
Backend-RF002-DeletarCanvasAutomatico

### DIFF
--- a/server/src/PushIt/Program.cs
+++ b/server/src/PushIt/Program.cs
@@ -34,6 +34,8 @@ builder.Services.AddDbContext<PushItContext>(options =>
     options.UseSqlite(connectionString);
 });
 
+builder.Services.AddHostedService<AutoDeleteCanvasService>();
+
 var app = builder.Build(); //"constrói" um server de acordo com as configurações definidas anteriormente na pipeline
 
 using (IServiceScope scope = app.Services.CreateScope()) //gera um service compatível com a keyword "using"

--- a/server/src/PushIt/Requests/PushIt.http
+++ b/server/src/PushIt/Requests/PushIt.http
@@ -12,7 +12,7 @@ Content-Type: application/json
 
 {
     "Name":"Validação Teste",
-    "CreatedDateTime":"2025-04-22T15:00:00"
+    "CreatedDateTime":"2025-05-26T15:00:00"
 }
 
 

--- a/server/src/PushIt/Services/AutoDeleteCanvasService.cs
+++ b/server/src/PushIt/Services/AutoDeleteCanvasService.cs
@@ -1,0 +1,82 @@
+
+using System.Reflection.Metadata.Ecma335;
+using Microsoft.EntityFrameworkCore;
+
+public class AutoDeleteCanvasService : IHostedService, IDisposable
+{
+    private Timer? _timer;
+    private const int intervalTimeHours = 24;
+    private const double CanvasExpireTimeHours = 24d;
+
+    private readonly IServiceProvider _serviceProvider;
+    public AutoDeleteCanvasService(IServiceProvider serviceProvider)
+    {
+        this._serviceProvider = serviceProvider;
+    }
+    
+    //inicia o processo cíclico (1 vez por dia) de varredura da Database 
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        this._timer = new Timer(this.DeleteOldCanvas, null, TimeSpan.Zero, TimeSpan.FromHours(intervalTimeHours));
+        return Task.CompletedTask;
+    }
+
+    private void DeleteOldCanvas(object? _)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<PushItContext>();
+
+        //busca por todos os canvas criados a mais de 24 horas
+        var c_queryResult = dbContext.canvas.ToList()
+                                            .Where(
+                                            c => DateTime.Now.ToUniversalTime()
+                                            .Subtract(c.CreatedDateTime.ToUniversalTime())
+                                            .TotalHours >= CanvasExpireTimeHours);
+
+        if (c_queryResult is not null)
+        {
+            List<CanvasEntity> expiredCanvas = c_queryResult.ToList();
+
+            foreach (var canvasEntity in expiredCanvas)
+            {
+                //obter todos os quadros do canvas
+                var cq_queryResult = from cq in dbContext.canvasQuadros.Include("quadro")
+                                     where cq.nomeCanvas == canvasEntity.Name
+                                     select cq.quadro;
+
+                if (cq_queryResult is not null)
+                {
+                    List<QuadrosEntity> quadros = cq_queryResult.ToList();
+                    
+                    //deleta da Database todas as conexoes que partem daquele quadro e deleta o próprio quadro
+                    foreach (QuadrosEntity quadro in quadros)
+                    {
+                        dbContext.conexoes.Where(con => con.QuadroComeco.id == quadro.id).ExecuteDelete();
+                        dbContext.quadros.Remove(quadro);
+                    }
+                }
+                //deleta da Database todas as entradas que vinculam o canvas a um quadro e deleta o próprio canvas
+                dbContext.canvasQuadros.Where(cq => cq.nomeCanvas == canvasEntity.Name).ExecuteDelete();
+                dbContext.Remove(canvasEntity);
+
+                //para de fato salvar as alterações feitas pelo dbContext.Remove() 
+                dbContext.SaveChanges();
+            }
+        }                                                
+        
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        this._timer!.Change(Timeout.Infinite, 0);
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        if(this._timer is not null)
+        {
+            this._timer.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Implementação de varredura diária da Database que deleta todos os Canvas (e seus respectivos quadros e conexões) que tenham sido criados há mais de 24 horas.